### PR TITLE
fix: do not display windows error popup when ffmpeg crashes

### DIFF
--- a/audioread/ffdec.py
+++ b/audioread/ffdec.py
@@ -16,6 +16,7 @@
 output.
 """
 
+import sys
 import subprocess
 import re
 import threading
@@ -73,10 +74,24 @@ class QueueReaderThread(threading.Thread):
 class FFmpegAudioFile(object):
     """An audio file decoded by the ffmpeg command-line utility."""
     def __init__(self, filename, block_size=4096):
+        # creation_flag default value
+        subprocess_flags = 0
+        # for windows, we set a custom creationflag to be passed to popen
+        # to avoid the Windows GPF dialog if the invoked program dies.
+        if sys.platform.startswith("win"):
+            # See comp.os.ms-windows.programmer.win32
+            # How to suppress crash notification dialog?, Jan 14,2004 -
+            # Raymond Chen's response [1]
+            import ctypes
+            SEM_NOGPFAULTERRORBOX = 0x0002 # From MSDN
+            ctypes.windll.kernel32.SetErrorMode(SEM_NOGPFAULTERRORBOX);
+            subprocess_flags = 0x8000000 #win32con.CREATE_NO_WINDOW?
+
         try:
             self.proc = subprocess.Popen(
                 ['ffmpeg', '-i', filename, '-f', 's16le', '-'],
-                stdout=subprocess.PIPE, stderr=subprocess.PIPE
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                creationflags=subprocess_flags,
             )
         except OSError:
             raise NotInstalledError()

--- a/audioread/ffdec.py
+++ b/audioread/ffdec.py
@@ -74,19 +74,14 @@ class QueueReaderThread(threading.Thread):
 class FFmpegAudioFile(object):
     """An audio file decoded by the ffmpeg command-line utility."""
     def __init__(self, filename, block_size=4096):
-        # creation_flag default value
+        # creationflags default value for non windows os
         subprocess_flags = 0
-        # for windows, we set a custom creationflag to be passed to popen
+        # for windows, we set a custom creationflags to be passed to popen
         # to avoid the Windows GPF dialog if the invoked program dies.
+        # see
+        # http://stackoverflow.com/questions/5069224/handling-subprocess-crash-in-windows/5103935#5103935
         if sys.platform.startswith("win"):
-            # See comp.os.ms-windows.programmer.win32
-            # How to suppress crash notification dialog?, Jan 14,2004 -
-            # Raymond Chen's response [1]
-            import ctypes
-            SEM_NOGPFAULTERRORBOX = 0x0002 # From MSDN
-            ctypes.windll.kernel32.SetErrorMode(SEM_NOGPFAULTERRORBOX);
-            subprocess_flags = 0x8000000 #win32con.CREATE_NO_WINDOW?
-
+            subprocess_flags = 0x8000000 | 0x0002
         try:
             self.proc = subprocess.Popen(
                 ['ffmpeg', '-i', filename, '-f', 's16le', '-'],

--- a/audioread/ffdec.py
+++ b/audioread/ffdec.py
@@ -74,22 +74,28 @@ class QueueReaderThread(threading.Thread):
 class FFmpegAudioFile(object):
     """An audio file decoded by the ffmpeg command-line utility."""
     def __init__(self, filename, block_size=4096):
-        # creationflags default value for non windows os
-        subprocess_flags = 0
-        # for windows, we set a custom creationflags to be passed to popen
-        # to avoid the Windows GPF dialog if the invoked program dies.
-        # see
-        # http://stackoverflow.com/questions/5069224/handling-subprocess-crash-in-windows/5103935#5103935
-        if sys.platform.startswith("win"):
-            subprocess_flags = 0x8000000 | 0x0002
+        self.is_windows = sys.platform.startswith("win")
         try:
+            if self.is_windows:
+                # by default, windows will display a dialog if the subprocess dies.
+                # passing SEM_NOGPFAULTERRORBOX to SetErrorMode disable this behavior 
+                SEM_NOGPFAULTERRORBOX=0x0002
+                import ctypes
+                # we call SetErrorMode in 2 steps to avoid overriding existing error mode
+                previous_error_mode = ctypes.windll.kernel32.SetErrorMode(SEM_NOGPFAULTERRORBOX)
+                ctypes.windll.kernel32.SetErrorMode(previous_error_mode|SEM_NOGPFAULTERRORBOX)
+
             self.proc = subprocess.Popen(
                 ['ffmpeg', '-i', filename, '-f', 's16le', '-'],
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                creationflags=subprocess_flags,
             )
         except OSError:
             raise NotInstalledError()
+        finally:
+            if self.is_windows:
+                import ctypes
+                # reset previous error mode
+                ctypes.windll.kernel32.SetErrorMode(previous_error_mode)
 
         # Start another thread to consume the standard output of the
         # process, which contains raw audio data.


### PR DESCRIPTION
Hi.
On another poject using ffmpeg, I came accross a nasty behavior on windows when, for any reason, a process spawned by subprocess.popen crashes.

By default,  windows will display an error pop-up like this one, instead of lettting the process die silently (in a user perspective)

(in this case, this is ffprobe crashing when trying to read an h264 video, but the result would be the same with an ffmpeg crash if/when it would happen)
 
![screen shot 2015-03-26 at 11 13 55](https://cloud.githubusercontent.com/assets/11556/6844757/0392b15a-d3ae-11e4-8c94-0a0cddbad0f8.png)

Windows will display one pop-up per crash (and if this happen on a large number of files, this would be total a mess for the user)

This PR aims to avoid this behavior on windows by setting error mode to [SEM_NOGPFAULTERRORBOX](https://msdn.microsoft.com/en-us/library/windows/desktop/ms680621%28v=vs.85%29.aspx) and pass SEM_NOOPENFILEERRORBOX as a a flag to popen.
This solution is based on this [stack overflow answer](http://stackoverflow.com/a/5103935).